### PR TITLE
fix: remove "ena" signal from the Chisel module IO

### DIFF
--- a/src/main/scala/ChiselTop.scala
+++ b/src/main/scala/ChiselTop.scala
@@ -11,7 +11,6 @@ class ChiselTop() extends Module {
     val uio_in = Input(UInt(8.W))     // IOs: Input path
     val uio_out = Output(UInt(8.W))   // IOs: Output path
     val uio_oe = Output(UInt(8.W))    // IOs: Enable path (active high: 0=input, 1=output)
-    val ena = Input(Bool())           // will go high when the design is enabled
   })
 
   io.uio_out := 0.U

--- a/src/tt_um_chisel_template.v
+++ b/src/tt_um_chisel_template.v
@@ -11,7 +11,7 @@ module tt_um_example (
     input  wire [7:0] uio_in,   // IOs: Input path
     output wire [7:0] uio_out,  // IOs: Output path
     output wire [7:0] uio_oe,   // IOs: Enable path (active high: 0=input, 1=output)
-    input  wire       ena,      // will go high when the design is enabled
+    input  wire       ena,      // always 1 when the design is powered, so you can ignore it
     input  wire       clk,      // clock
     input  wire       rst_n     // reset_n - low to reset
 );
@@ -29,7 +29,8 @@ module tt_um_example (
       .io_uo_out(uo_out),
       .io_uio_in(uio_in),
       .io_uio_out(uio_out),
-      .io_uio_oe(uio_oe),
-      .io_ena(ena));
+      .io_uio_oe(uio_oe));
+
+    wire _unused = &{ ena };
 
 endmodule


### PR DESCRIPTION
It's always 1 when the design is powered, so it's useless for digital designs.

We found that it can confuse users to think it's another input line they can control (which is not the case). 

So IMHO it's better not to expose `ena` to the Chisel module.